### PR TITLE
Adds "a" as a prefix to the APP_ID in Android to avoid Java parses the app id as a number (sometimes float)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -99,7 +99,8 @@
     <access origin="https://passport.weibo.cn/*"/>
     <access origin="http://*.sinaimg.cn/*"/>
     <access origin="https://api.weibo.com/*"/>
-    <preference name="WEIBO_APP_ID" value="$WEIBO_APP_ID"/>
+    <!-- Adds "a" as a prefix to avoid large integer being parsed as numbers and represented as floats -->
+    <preference name="WEIBO_APP_ID" value="a$WEIBO_APP_ID"/>
   </config-file>
   <!-- android  uses-permission for weibo sdk-->
   <config-file target="AndroidManifest.xml" parent="/manifest">

--- a/src/android/WeiboSDKPlugin.java
+++ b/src/android/WeiboSDKPlugin.java
@@ -55,7 +55,8 @@ public class WeiboSDKPlugin extends CordovaPlugin implements WbShareCallback {
     @Override
     protected void pluginInitialize() {
         super.pluginInitialize();
-        APP_KEY = webView.getPreferences().getString(WEBIO_APP_ID, "");
+        // The first letter "a" was added in plugin.xml to avoid the string be parsed as a number, remove it here.
+        APP_KEY = webView.getPreferences().getString(WEBIO_APP_ID, "a").substring(1);
         REDIRECT_URL = webView.getPreferences().getString(WEBIO_REDIRECT_URL, DEFAULT_URL);
         WbSdk.install(WeiboSDKPlugin.this.cordova.getActivity(),new AuthInfo(WeiboSDKPlugin.this.cordova.getActivity(), APP_KEY, REDIRECT_URL, SCOPE));
     }


### PR DESCRIPTION
Please also see discussion in https://github.com/iVanPan/cordova_weibo/issues/58