### PR TITLE
调用 shareHandler 前确保其非 null

### DIFF
--- a/src/android/WeiboSDKPlugin.java
+++ b/src/android/WeiboSDKPlugin.java
@@ -415,7 +415,9 @@ public class WeiboSDKPlugin extends CordovaPlugin implements WbShareCallback {
     @Override
     public void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
-        WeiboSDKPlugin.shareHandler.doResultIntent(intent,this);
+        if (WeiboSDKPlugin.shareHandler != null) {
+          WeiboSDKPlugin.shareHandler.doResultIntent(intent,this);
+        }
     }
 
     private class SelfWbAuthListener implements com.sina.weibo.sdk.auth.WbAuthListener{


### PR DESCRIPTION
某些测试系统会 trigger onNewIntent，继而导致 null exeception
02-13 14:09:11.620 10300 13932 13932 E AndroidRuntime: java.lang.NullPointerException: Attempt to invoke virtual method 'void com.sina.weibo.sdk.share.WbShareHandler.doResultIntent(android.content.Intent, com.sina.weibo.sdk.share.WbShareCallback)' on a null object reference
02-13 14:09:11.620 10300 13932 13932 E AndroidRuntime: at me.vanpan.weibosdk.WeiboSDKPlugin.onNewIntent(WeiboSDKPlugin.java:420)
02-13 14:09:11.620 10300 13932 13932 E AndroidRuntime: at org.apache.cordova.PluginManager.onNewIntent(PluginManager.java:327)
02-13 14:09:11.620 10300 13932 13932 E AndroidRuntime: at org.apache.cordova.CordovaWebViewImpl.onNewIntent(CordovaWebViewImpl.java:422)
02-13 14:09:11.620 10300 13932 13932 E AndroidRuntime: at org.apache.cordova.CordovaActivity.onNewIntent(CordovaActivity.java:257)
02-13 14:09:11.620 10300 13932 13932 E AndroidRuntime: at android.app.Activity.performNewIntent(Activity.java:7213)